### PR TITLE
Update license copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 RevoTale
+Copyright (c) 2023 Liakhovskyi Vladyslav <l-you@revotale.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- replace the RevoTale copyright holder with Liakhovskyi Vladyslav
- add the copyright contact email
- preserve the original copyright year and MIT license text

## Validation

Documentation-only change; no runtime checks required.